### PR TITLE
Empty default values & multiple args fix

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.38
+version: 0.1.39

--- a/charts/app/templates/replicas.yaml
+++ b/charts/app/templates/replicas.yaml
@@ -41,8 +41,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "app.serviceAccountName" . }}
+      {{- if .Values.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
       {{- if or (or .Values.configMaps .Values.secrets) .Values.volumes }}
       volumes:
       {{- range $name, $settings := .Values.configMaps }}
@@ -76,9 +78,11 @@ spec:
         {{- end }}
 
         - name: {{ .Chart.Name }}
+          {{- if .Values.podSecurityContext }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          {{- end }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion | default "latest"}}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.command }}
           command: {{ .Values.command }}
@@ -86,8 +90,9 @@ spec:
           {{- if .Values.args }}
           args: {{ .Values.args }}
           {{- end }}
-
+          {{- if .Values.env }}
           env: {{ toYaml .Values.env | nindent 12 }}
+          {{- end}}
 
           {{- if or .Values.secrets (or .Values.configMaps (eq .Values.replicasKind "StatefulSet")) }}
           volumeMounts:
@@ -134,8 +139,10 @@ spec:
             {{- else }}
             {{- toYaml .Values.defaultReadinessProbe | nindent 12 }}
             {{- end}}
+          {{- if .Values.resources }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/app/templates/replicas.yaml
+++ b/charts/app/templates/replicas.yaml
@@ -88,7 +88,9 @@ spec:
           command: {{ .Values.command }}
           {{- end }}
           {{- if .Values.args }}
-          args: {{ .Values.args }}
+          args: {{ range .Values.args }}
+          - {{ . }}
+          {{- end }}
           {{- end }}
           {{- if .Values.env }}
           env: {{ toYaml .Values.env | nindent 12 }}


### PR DESCRIPTION
closes https://github.com/vegaprotocol/devops-infra/issues/1721

- do not display empty section: {}` or `[]` was displayed on its own line before fix, which was breaking yaml
- display each `args` on its own line, was concatening all items as a single array item before fix